### PR TITLE
Update tutorial_default.md

### DIFF
--- a/install_from_source/tutorial_default.md
+++ b/install_from_source/tutorial_default.md
@@ -61,9 +61,6 @@ the default branch. In an Ubuntu system, several Personal Package Archives
 (PPA's) can be used to install the proper package and dependencies. Note that
 adding these PPA's may cause conflicts with ROS.
 
-    # Only needed on Trusty. Ubuntu packages since Utopic.
-    sudo apt-add-repository ppa:libccd-debs
-    sudo apt-add-repository ppa:fcl-debs
 
     # Main repository
     sudo apt-add-repository ppa:dartsim


### PR DESCRIPTION
Hey, my first PR on GitHub, tried to solve issue#133 which asks to remove references to Trusty-specific steps for Install from Source for Gazebo >= 9.
As gazebo >= 9 does not support trusty.